### PR TITLE
fix: save plddt to pdb

### DIFF
--- a/esm/sdk/api.py
+++ b/esm/sdk/api.py
@@ -101,6 +101,7 @@ class ESMProtein:
             entity_id=None,
             residue_index=None,
             insertion_code=None,
+            confidence=None if self.plddt is None else self.plddt.detach().cpu().numpy(),
         )
         return protein_chain
 


### PR DESCRIPTION
Fixes #7 by passing plddt as confidence when creating a ProteinChain from atom37. This confidence gets stored in the pdb.