### PR TITLE
bug fix: mean_embedding is checking the wrong configuration argument

### DIFF
--- a/esm/models/esm3.py
+++ b/esm/models/esm3.py
@@ -680,7 +680,7 @@ class ESM3(nn.Module, ESM3InferenceClient):
         )
         mean_embedding = (
             forward_output.embeddings[0].mean(1)  # type: ignore
-            if sampling_configuration.return_per_residue_embeddings
+            if sampling_configuration.return_mean_embedding
             else None
         )
 

--- a/esm/models/esm3.py
+++ b/esm/models/esm3.py
@@ -679,7 +679,7 @@ class ESM3(nn.Module, ESM3InferenceClient):
             else None
         )
         mean_embedding = (
-            forward_output.embeddings[0].mean(1)  # type: ignore
+            forward_output.embeddings[0].mean(0)  # type: ignore
             if sampling_configuration.return_mean_embedding
             else None
         )


### PR DESCRIPTION
mean_embedding should check `sampling_configuration.return_mean_embedding`
not `sampling_configuration.return_per_residue_embeddings`

and the .mean ops is on wrong dimension