### PR TITLE
Fixed issue with EsmSequenceTokenizer

### DIFF
--- a/esm/tokenization/sequence_tokenizer.py
+++ b/esm/tokenization/sequence_tokenizer.py
@@ -63,47 +63,6 @@ class EsmSequenceTokenizer(PreTrainedTokenizerFast, EsmTokenizerBase):
             **kwargs,
         )
 
-    # These are a footgun, we never use the `bos` token anywhere so we're just overriding it here.
-    @property
-    def bos_token(self):
-        return self.cls_token
-
-    @property
-    def bos_token_id(self):
-        return self.cls_token_id
-
-    @property
-    def cls_token(self):
-        return self._get_token("cls_token")
-
-    @property
-    def cls_token_id(self):
-        return self._get_token_id(self.cls_token)
-
-    @property
-    def eos_token(self):
-        return self._get_token("eos_token")
-
-    @property
-    def eos_token_id(self):
-        return self._get_token_id(self.eos_token)
-
-    @property
-    def mask_token(self):
-        return self._get_token("mask_token")
-
-    @property
-    def mask_token_id(self):
-        return self._get_token_id(self.mask_token)
-
-    @property
-    def pad_token(self):
-        return self._get_token("pad_token")
-
-    @property
-    def pad_token_id(self):
-        return self._get_token_id(self.pad_token)
-
     @property
     def chain_break_token(self):
         return self.cb_token


### PR DESCRIPTION
Simple PR to fix an issue with the EsmSequenceTokenizer class. The property based access for the special tokens defined in EsmSequenceTokenizer cause the __init__ function to fail since there are no setters. See #214 for more details!