### PR TITLE
Fix CUDA memory leak in decode_structure

### DIFF
--- a/esm/utils/decoding.py
+++ b/esm/utils/decoding.py
@@ -161,8 +161,15 @@ def decode_structure(
         plddt = plddt[0, 1:-1].detach().cpu()
 
     ptm = decoder_output.get("ptm", None)
+    if ptm is not None:
+        ptm = ptm.detach().cpu()  # fix memory leak
 
     pae = decoder_output.get("predicted_aligned_error", None)
+    if pae is not None:
+        pae = pae.detach().cpu()  # fix memory leak
+    # free decoder output
+    del decoder_output  
+    torch.cuda.empty_cache()  
 
     chain = ProteinChain.from_backbone_atom_coordinates(bb_coords, sequence=sequence)
     chain = chain.infer_oxygen()


### PR DESCRIPTION
Addresses a memory leak in the decoding. 

**Problem:**
Pae and ptm tensors were not moved to CPU, leading to GPU memory accumulation.  
This behavior is benign when batch size is 1 in batch_generate(), but when batch size > 1 it leads to a OOM error. 

**Fix**
Move to pae and ptm tensors to CPU. 