### PR TITLE
Type max_inference_sigma as float | None to match downstream consumer

### DIFF
--- a/esm/models/esmfold2/processor.py
+++ b/esm/models/esmfold2/processor.py
@@ -294,7 +294,7 @@ class ESMFold2InputBuilder:
         seed: int | None = None,
         noise_scale: float | None = None,
         step_scale: float | None = None,
-        max_inference_sigma: int | None = None,
+        max_inference_sigma: float | None = None,
         early_exit: bool = False,
         complex_id: str = "pred",
     ) -> MolecularComplexResult | list[MolecularComplexResult]:


### PR DESCRIPTION
The `fold()` / `prepare_input()` signature in `esm/models/esmfold2/processor.py` types `max_inference_sigma` as `int | None`, but the downstream consumer in `transformers/models/esmfold2/modeling_esmfold2_common.py:1722` types it as `float | None = 256.0` and casts `float(max_inference_sigma)` at the use site.

Sigma is a continuous quantity along the Karras schedule, so float is the correct type. The default value (`256.0`) is already a float. This patch aligns the user-facing API type annotation with what the model consumes.