### PR TITLE
Fix ESMC 300M/600M local loading: torch.load the .pth (repos ship no safetensors)

### DIFF
--- a/esm/pretrained.py
+++ b/esm/pretrained.py
@@ -72,7 +72,14 @@ def ESMC_300M_202412(device: torch.device | str = "cpu", use_flash_attn: bool = 
             tokenizer=get_esmc_model_tokenizers(),
             use_flash_attn=use_flash_attn,
         ).eval()
-    load_torch_model(model, data_root("esmc-300"))
+    # The 300M repo ships a single legacy .pth (no safetensors), so load it
+    # explicitly like the ESM3 loaders above rather than via load_torch_model,
+    # which (safe=True) expects a safetensors checkpoint in the directory.
+    state_dict = torch.load(
+        data_root("esmc-300") / "data/weights/esmc_300m_2024_12_v0.pth",
+        map_location=device,
+    )
+    model.load_state_dict(state_dict, assign=True)
     model = model.to(device)
     return model
 
@@ -86,7 +93,14 @@ def ESMC_600M_202412(device: torch.device | str = "cpu", use_flash_attn: bool = 
             tokenizer=get_esmc_model_tokenizers(),
             use_flash_attn=use_flash_attn,
         ).eval()
-    load_torch_model(model, data_root("esmc-600"))
+    # The 600M repo ships a single legacy .pth (no safetensors), so load it
+    # explicitly like the ESM3 loaders above rather than via load_torch_model,
+    # which (safe=True) expects a safetensors checkpoint in the directory.
+    state_dict = torch.load(
+        data_root("esmc-600") / "data/weights/esmc_600m_2024_12_v0.pth",
+        map_location=device,
+    )
+    model.load_state_dict(state_dict, assign=True)
     model = model.to(device)
     return model
 


### PR DESCRIPTION
ESMC.from_pretrained("esmc_300m") and ("esmc_600m") currently fail with:

```
ValueError: Directory ".../snapshots/..." does not contain a valid checkpoint.
Expected either a sharded checkpoint with an index file, or a single model file.
```

### Cause
`ESMC_300M_202412` / `ESMC_600M_202412` in `esm/pretrained.py` load weights via
`load_torch_model(model, data_root("esmc-300"|"esmc-600"))`. `huggingface_hub.load_torch_model`
defaults to `safe=True`, so given a directory it looks for a safetensors checkpoint.
But the `biohub/esmc-300m-2024-12` and `biohub/esmc-600m-2024-12` repos ship a single
legacy checkpoint at `data/weights/esmc_*_2024_12_v0.pth` and **no** safetensors — so the
lookup fails.

The 6B repo (`biohub/esmc-6b-2024-12`) ships sharded safetensors + an index, so its
loader works; this PR leaves it unchanged.

### Fix
Load the `.pth` explicitly with `torch.load` + `load_state_dict(assign=True)`, exactly
as the `ESM3_*` loaders in the same file already do.

### Testing
Verified `esmc_600m` loads and runs end-to-end on a GPU (downloads the `.pth`, builds
the model with `d_model=1152, n_heads=18, n_layers=36`, embeds 65 protein sequences via
`logits(..., return_embeddings=True)`). The `esmc_300m` change is the identical pattern
against the verified `data/weights/esmc_300m_2024_12_v0.pth` filename.