### PR TITLE
Expose ESMFold2 MSA inference-diversity knobs in local fold()

### DIFF
--- a/esm/models/esmfold2/processor.py
+++ b/esm/models/esmfold2/processor.py
@@ -341,7 +341,6 @@ class ESMFold2InputBuilder:
         lm_dropout: float | None = 0.3,
         msa_max_depth: int = 1024,
         msa_column_mask_rate: float = 0.1,
-        msa_subsample_at_inference: bool = True,
         complex_id: str = "pred",
     ) -> MolecularComplexResult | list[MolecularComplexResult]:
         """Fold a structure end-to-end: encode → model → decode.
@@ -371,9 +370,6 @@ class ESMFold2InputBuilder:
         msa_column_mask_rate : float
             Fraction of MSA columns masked once before the loop
             (shared across loops). Only affects inputs that carry an MSA.
-        msa_subsample_at_inference : bool
-            Whether to subsample MSA rows at inference time. The query row is
-            always kept. Only affects inputs that carry an MSA.
         complex_id : str
             Identifier assigned to the predicted MolecularComplex(es).
 
@@ -407,7 +403,6 @@ class ESMFold2InputBuilder:
                         early_exit=early_exit,
                         msa_max_depth=msa_max_depth,
                         msa_column_mask_rate=msa_column_mask_rate,
-                        msa_subsample_at_inference=msa_subsample_at_inference,
                         **sampler_kwargs,
                     )
 

--- a/esm/models/esmfold2/processor.py
+++ b/esm/models/esmfold2/processor.py
@@ -339,6 +339,9 @@ class ESMFold2InputBuilder:
         lm_mask_pct: float | None = None,
         early_exit: bool = False,
         lm_dropout: float | None = 0.3,
+        msa_max_depth: int = 1024,
+        msa_column_mask_rate: float = 0.1,
+        msa_subsample_at_inference: bool = True,
         complex_id: str = "pred",
     ) -> MolecularComplexResult | list[MolecularComplexResult]:
         """Fold a structure end-to-end: encode → model → decode.
@@ -362,6 +365,15 @@ class ESMFold2InputBuilder:
             LM-embedding dropout for this fold (fresh mask per loop → diverse
             ensemble on repeated folds). Defaults to ``0.3`` (paper folding-eval
             value); ``0``/``None`` disables.
+        msa_max_depth : int
+            Maximum number of MSA rows kept per loop (row subsampling
+            is drawn fresh per loop). Only affects inputs that carry an MSA.
+        msa_column_mask_rate : float
+            Fraction of MSA columns masked once before the loop
+            (shared across loops). Only affects inputs that carry an MSA.
+        msa_subsample_at_inference : bool
+            Whether to subsample MSA rows at inference time. The query row is
+            always kept. Only affects inputs that carry an MSA.
         complex_id : str
             Identifier assigned to the predicted MolecularComplex(es).
 
@@ -393,6 +405,9 @@ class ESMFold2InputBuilder:
                         num_sampling_steps=num_sampling_steps,
                         num_diffusion_samples=num_diffusion_samples,
                         early_exit=early_exit,
+                        msa_max_depth=msa_max_depth,
+                        msa_column_mask_rate=msa_column_mask_rate,
+                        msa_subsample_at_inference=msa_subsample_at_inference,
                         **sampler_kwargs,
                     )
 


### PR DESCRIPTION
The transformers ESMFold2Model.forward accepts msa_max_depth, msa_column_mask_rate, and msa_subsample_at_inference, but the local ESMFold2InputBuilder.fold() entrypoint didn't surface them, so users running ESMFold2 locally couldn't access the feature.

Add the three knobs to fold() and forward them to the model. Defaults match the model's hardcoded values (1024 / 0.1 / True), so behavior is unchanged unless set; they only take effect for inputs that carry an MSA.