### PR TITLE
Create THIRD_PARTY_NOTICE.md

### DIFF
--- a/THIRD_PARTY_NOTICE.md
+++ b/THIRD_PARTY_NOTICE.md
@@ -1,0 +1,13 @@
+The code in this repository depends on the following third-party libraries:
+
+| Library | License | Link |
+|----------|----------|----------|
+| flash-attn | BSD | https://github.com/Dao-AILab/flash-attention/blob/main/LICENSE |
+| PyTorch | BSD | https://github.com/pytorch/pytorch/blob/main/LICENSE |
+| xformers | BSD | https://github.com/facebookresearch/xformers/blob/main/LICENSE |
+| jaxtyping | MIT | https://github.com/patrick-kidger/jaxtyping/blob/main/LICENSE |
+| einops | MIT | https://github.com/arogozhnikov/einops/blob/main/LICENSE |
+| omegaconf | BSD | https://github.com/omry/omegaconf/blob/master/LICENSE |
+| attrs | MIT | https://github.com/python-attrs/attrs/blob/main/LICENSE |
+| scipy | BSD-3-Clause | https://github.com/scipy/scipy/blob/main/LICENSE.txt<br>https://github.com/scipy/scipy/blob/main/LICENSES_bundled.txt |
+| lightning / torchmetrics | Apache 2.0 | https://github.com/Lightning-AI/torchmetrics/blob/master/LICENSE |


### PR DESCRIPTION
Fixing link to third party notice required for all ESM models by adding the file to the correct location in this repo.