### PR TITLE
Fix infer_cbeta corrupting the cached inferred_cbeta array

### DIFF
--- a/esm/utils/structure/protein_chain.py
+++ b/esm/utils/structure/protein_chain.py
@@ -1244,7 +1244,9 @@ class ProteinChain:
         atom37_positions = self.atom37_positions.copy()
         atom37_mask = self.atom37_mask.copy()
 
-        inferred_cbeta_positions = self.inferred_cbeta
+        # Copy so the in-place glycine NaN-fill below does not mutate the cached
+        # `inferred_cbeta` array (and everything derived from it, e.g. pdist_CB).
+        inferred_cbeta_positions = self.inferred_cbeta.copy()
         if not infer_cbeta_for_glycine:
             inferred_cbeta_positions[np.array(list(self.sequence)) == "G", :] = np.nan
 

--- a/esm/utils/structure/protein_chain_test.py
+++ b/esm/utils/structure/protein_chain_test.py
@@ -1,0 +1,37 @@
+"""Tests for protein_chain.py"""
+
+import numpy as np
+
+from esm.utils.structure.protein_chain import ProteinChain
+
+
+def _make_chain(sequence: str) -> ProteinChain:
+    n = len(sequence)
+    rng = np.random.default_rng(0)
+    coords = rng.uniform(-10, 10, (n, 37, 3)).astype(np.float32)
+    return ProteinChain(
+        id="test",
+        sequence=sequence,
+        chain_id="A",
+        entity_id=1,
+        residue_index=np.arange(n),
+        insertion_code=np.full(n, "", dtype="<U4"),
+        atom37_positions=coords,
+        atom37_mask=np.ones((n, 37), dtype=bool),
+        confidence=np.ones(n),
+    )
+
+
+def test_infer_cbeta_does_not_mutate_cached_inferred_cbeta():
+    # infer_cbeta() NaN-fills the glycine CB positions to build a *new* chain; it
+    # must not mutate the original chain's cached `inferred_cbeta` array (nor
+    # anything derived from it, such as pdist_CB).
+    chain = _make_chain("AGA")  # glycine at index 1
+
+    original = chain.inferred_cbeta.copy()
+    original_pdist = chain.pdist_CB.copy()
+
+    chain.infer_cbeta()
+
+    np.testing.assert_array_equal(chain.inferred_cbeta, original)
+    np.testing.assert_array_equal(chain.pdist_CB, original_pdist)


### PR DESCRIPTION
No linked issue — found by reading the code.

## The bug

`ProteinChain.infer_cbeta()` builds a *new* chain whose glycine CB positions are NaN (unless `infer_cbeta_for_glycine=True`). To do so it takes the cached `inferred_cbeta` array **by reference** and NaN-fills the glycine rows **in place**:

```python
inferred_cbeta_positions = self.inferred_cbeta       # cached_property -> shared array
if not infer_cbeta_for_glycine:
    inferred_cbeta_positions[np.array(list(self.sequence)) == "G", :] = np.nan
```

Since `inferred_cbeta` is a `@cached_property`, this **permanently corrupts the original chain's cached array**, and everything derived from it (e.g. `pdist_CB`, which is `squareform(pdist(self.inferred_cbeta))`). So the value of `inferred_cbeta` / `pdist_CB` silently depends on whether `infer_cbeta()` was ever called:

```python
chain.inferred_cbeta[gly_idx]   # -> real inferred CB coordinate
chain.infer_cbeta()             # default call; intended to be side-effect-free
chain.inferred_cbeta[gly_idx]   # -> [nan, nan, nan]   (cache mutated)
```

## Why it's a bug (not intended)

- The same method already copies the other arrays before mutating them: `atom37_positions = self.atom37_positions.copy()` / `atom37_mask = self.atom37_mask.copy()`.
- The sibling `ProteinComplex.infer_cbeta` computes `inferred_cbeta_positions` into a fresh local, so it isn't affected.

## Fix

Copy the array before the in-place NaN-fill (`self.inferred_cbeta.copy()`). The returned chain is unchanged (glycine CB still masked by default, kept with `infer_cbeta_for_glycine=True`); only the mutation of the shared cache is removed.

## Testing

Added `esm/utils/structure/protein_chain_test.py::test_infer_cbeta_does_not_mutate_cached_inferred_cbeta`, asserting that `inferred_cbeta` and `pdist_CB` are unchanged after calling `infer_cbeta()`. It fails before this change and passes after. `ruff check` / `ruff format` are clean.