### PR TITLE
Fix local loading of all three ESMC checkpoints

### DIFF
--- a/cookbook/snippets/esmc.py
+++ b/cookbook/snippets/esmc.py
@@ -136,7 +136,6 @@ if __name__ == "__main__":
         print(
             "To try this script with a Forge/Biohub Platform API, please run ESM_API_KEY=your_api_key python esm3.py"
         )
-        main(ESMC.from_pretrained("esm3_sm_open_v1"))
         model = ESMC.from_pretrained("esmc_300m")
         main(model)
         raw_forward(model)

--- a/esm/pretrained.py
+++ b/esm/pretrained.py
@@ -1,10 +1,12 @@
 import inspect
+import json
+from pathlib import Path
 from typing import Callable
 
 import torch
 import torch.nn as nn
 from accelerate import init_empty_weights
-from huggingface_hub import load_torch_model
+from huggingface_hub import load_state_dict_from_file
 
 from esm.models.esm3 import ESM3
 from esm.models.esmc import ESMC
@@ -72,7 +74,11 @@ def ESMC_300M_202412(device: torch.device | str = "cpu", use_flash_attn: bool = 
             tokenizer=get_esmc_model_tokenizers(),
             use_flash_attn=use_flash_attn,
         ).eval()
-    load_torch_model(model, data_root("esmc-300"))
+    state_dict = torch.load(
+        data_root("esmc-300") / "data/weights/esmc_300m_2024_12_v0.pth",
+        map_location=device,
+    )
+    model.load_state_dict(state_dict, assign=True)
     model = model.to(device)
     return model
 
@@ -86,9 +92,36 @@ def ESMC_600M_202412(device: torch.device | str = "cpu", use_flash_attn: bool = 
             tokenizer=get_esmc_model_tokenizers(),
             use_flash_attn=use_flash_attn,
         ).eval()
-    load_torch_model(model, data_root("esmc-600"))
+    state_dict = torch.load(
+        data_root("esmc-600") / "data/weights/esmc_600m_2024_12_v0.pth",
+        map_location=device,
+    )
+    model.load_state_dict(state_dict, assign=True)
     model = model.to(device)
     return model
+
+
+def _esmc_6b_state_dict(root: Path) -> dict[str, torch.Tensor]:
+    """Read the sharded ESMC 6B checkpoint under ESMC's own parameter names.
+
+    The published weights are exported from the HuggingFace ``ESMCForMaskedLM``
+    wrapper, which nests the backbone under ``esmc.`` and names the output head
+    ``lm_head``. ``ESMC`` holds those same modules at the top level, with the head
+    as ``sequence_head``.
+    """
+    index = json.loads((root / "model.safetensors.index.json").read_text())
+    shards: dict[str, torch.Tensor] = {}
+    for shard in sorted(set(index["weight_map"].values())):
+        shards.update(load_state_dict_from_file(root / shard))
+
+    state_dict = {}
+    for key, value in shards.items():
+        if key.startswith("esmc."):
+            key = key[len("esmc.") :]
+        elif key.startswith("lm_head."):
+            key = "sequence_head." + key[len("lm_head.") :]
+        state_dict[key] = value
+    return state_dict
 
 
 def ESMC_6B_202412(device: torch.device | str = "cpu", use_flash_attn: bool = True):
@@ -100,7 +133,8 @@ def ESMC_6B_202412(device: torch.device | str = "cpu", use_flash_attn: bool = Tr
             tokenizer=get_esmc_model_tokenizers(),
             use_flash_attn=use_flash_attn,
         ).eval()
-    load_torch_model(model, data_root("esmc-6b"))
+    state_dict = _esmc_6b_state_dict(data_root("esmc-6b"))
+    model.load_state_dict(state_dict, assign=True)
     model = model.to(device)
     return model
 


### PR DESCRIPTION
## Problem

Loading any ESMC checkpoint locally currently fails for me on `main`. I implemented this fix to get this to work and thought I would make a PR just in case.

```python
from esm.models.esmc import ESMC
ESMC.from_pretrained("esmc_300m")   # also esmc_600m, esmc_6b
```

| checkpoint | error |
| --- | --- |
| `esmc_300m` | `ValueError: Directory '...' does not contain a valid checkpoint` |
| `esmc_600m` | `ValueError: Directory '...' does not contain a valid checkpoint` |
| `esmc_6b` | `NotImplementedError: Cannot copy out of meta tensor; no data!` |

```
$ python cookbook/snippets/esmc.py
  File "cookbook/snippets/esmc.py", line 139, in <module>
    main(ESMC.from_pretrained("esm3_sm_open_v1"))
  File "esm/models/esmc.py", line 95, in from_pretrained
    assert isinstance(model, ESMC)
AssertionError
```

Three independent causes (notes from Claude):

- **300M / 600M** — [`pretrained.py#L75`](https://github.com/Biohub/esm/blob/26b0bc2b771e3e419ea74f445a5f35cc094a1509/esm/pretrained.py#L75) and [`#L89`](https://github.com/Biohub/esm/blob/26b0bc2b771e3e419ea74f445a5f35cc094a1509/esm/pretrained.py#L89) call `load_torch_model` on the snapshot root, but [`esmc-300m-2024-12`](https://huggingface.co/biohub/esmc-300m-2024-12/tree/main) and [`esmc-600m-2024-12`](https://huggingface.co/biohub/esmc-600m-2024-12/tree/main) have a single nested `data/weights/*.pth` with no index file at the root.
- **6B** — [`#L103`](https://github.com/Biohub/esm/blob/26b0bc2b771e3e419ea74f445a5f35cc094a1509/esm/pretrained.py#L103) loads [`esmc-6b-2024-12`](https://huggingface.co/biohub/esmc-6b-2024-12/tree/main), whose 808 keys are exported from the HF `ESMCForMaskedLM` wrapper (`esmc.*`, `lm_head.*`); `ESMC` expects them unprefixed with the head as `sequence_head`. `load_torch_model` defaults to `strict=False`, so every key is dropped silently, the parameters stay meta tensors from `init_empty_weights()`, and the failure only surfaces at `model.to(device)`.
- **Snippet** — [`esmc.py#L139`](https://github.com/Biohub/esm/blob/26b0bc2b771e3e419ea74f445a5f35cc094a1509/cookbook/snippets/esmc.py#L139) passes an ESM3 checkpoint name to `ESMC.from_pretrained`, which resolves to the `ESM3_sm_open_v0` builder and returns an `ESM3`: never an `ESMC`, so [the assert](https://github.com/Biohub/esm/blob/26b0bc2b771e3e419ea74f445a5f35cc094a1509/esm/models/esmc.py#L95) fails.

## Fix

**`esm/pretrained.py`** — all three ESMC builders load the state dict directly and apply it with `assign=True`, the pattern [`ESM3_sm_open_v0`](https://github.com/Biohub/esm/blob/26b0bc2b771e3e419ea74f445a5f35cc094a1509/esm/pretrained.py#L108) and the three ESM3 decoder builders above it already use. 6B additionally walks `model.safetensors.index.json` and maps `esmc.` → `` and `lm_head.` → `sequence_head.`. `load_torch_model` has no remaining callers, so the import is swapped for `load_state_dict_from_file`.

`assign=True` keeps `load_state_dict`'s default `strict=True`, so future key drift fails at the load site instead of silently.

**`cookbook/snippets/esmc.py`** — drop the `esm3_sm_open_v1` call. The two lines after it already load `esmc_300m` and pass it to `main()` and `raw_forward()`, so it is redundant as well as incorrect.

I verified these now work in a clean micromamba env, Python 3.12 via the `pip install -e .` set up path.

```
Client returned logits with shape: torch.Size([1, 7, 64]), embeddings with shape: torch.Size([1, 7, 960]), and hidden states with shape torch.Size([30, 1, 7, 960])
Client returned hidden states with shape torch.Size([1, 1, 7, 960])
Raw model returned logits with shape: torch.Size([2, 7, 64]), embeddings with shape: torch.Size([2, 7, 960]) and hidden states with shape torch.Size([30, 2, 7, 960])
```

## Notes
I found a few other things that appear to be out of date!

- The Hub download path has no CI coverage: [`data_root()`](https://github.com/Biohub/esm/blob/26b0bc2b771e3e419ea74f445a5f35cc094a1509/esm/utils/constants/esm3.py#L106) returns `Path("")` when `INFRA_PROVIDER` is set, and [`tests/Makefile#L4`](https://github.com/Biohub/esm/blob/26b0bc2b771e3e419ea74f445a5f35cc094a1509/tests/Makefile#L4) always sets it.
- [`CONTRIBUTIONS.md#L16`](https://github.com/Biohub/esm/blob/26b0bc2b771e3e419ea74f445a5f35cc094a1509/CONTRIBUTIONS.md#L16) specifies Python 3.10, but [`pyproject.toml#L6`](https://github.com/Biohub/esm/blob/26b0bc2b771e3e419ea74f445a5f35cc094a1509/pyproject.toml#L6) requires `>=3.12,<3.13`, so `pip install -e .` fails on 3.10.
- [`CONTRIBUTIONS.md#L20`](https://github.com/Biohub/esm/blob/26b0bc2b771e3e419ea74f445a5f35cc094a1509/CONTRIBUTIONS.md#L20) references `examples/requirements.txt`; there is no `examples/` directory.
